### PR TITLE
unsafeCoerce bug fix(!), specialised single-element Vault, performance

### DIFF
--- a/src/Data/Vault.hs
+++ b/src/Data/Vault.hs
@@ -10,9 +10,9 @@
 module Data.Vault (
     Vault, Key,
     empty, newKey, lookup, insert, adjust, delete, union,
-    -- * Boxes
-    Box,
-    toBox, fromBox,
+    -- * Lockers
+    Locker,
+    lock, unlock,
     ) where
 
 import Prelude hiding (lookup)
@@ -62,13 +62,13 @@ union = ST.union
 
 -- | An efficient implementation of a single-element @Vault@.
 --
--- > type Box :: *
-type Box = ST.Box RealWorld
+-- > type Locker :: *
+type Locker = ST.Locker RealWorld
 
--- | @toBox k a@ is analogous to @insert k a empty@.
-toBox :: Key a -> a -> Box
-toBox = ST.toBox
+-- | @lock k a@ is analogous to @insert k a empty@.
+lock :: Key a -> a -> Locker
+lock = ST.lock
 
--- | @fromBox k a@ is analogous to @lookup k a@.
-fromBox :: Key a -> Box -> Maybe a
-fromBox = ST.fromBox
+-- | @unlock k a@ is analogous to @lookup k a@.
+unlock :: Key a -> Locker -> Maybe a
+unlock = ST.unlock

--- a/src/Data/Vault/ST.hs
+++ b/src/Data/Vault/ST.hs
@@ -10,9 +10,9 @@
 module Data.Vault.ST (
     Vault, Key,
     empty, newKey, lookup, insert, adjust, delete, union,
-    -- * Boxes
-    Box,
-    toBox, fromBox,
+    -- * Lockers
+    Locker,
+    lock, unlock,
     ) where
 
 import Prelude hiding (lookup)
@@ -82,14 +82,14 @@ union :: Vault s -> Vault s -> Vault s
 union (Vault m) (Vault m') = Vault $ IntMap.union m m'
 
 -- | An efficient implementation of a single-element @Vault s@.
-data Box s = Box !Int Any
+data Locker s = Locker !Int Any
 
--- | @toBox k a@ is analogous to @insert k a empty@.
-toBox :: Key s a -> a -> Box s
-toBox (Key k) = Box k . toAny
+-- | @lock k a@ is analogous to @insert k a empty@.
+lock :: Key s a -> a -> Locker s
+lock (Key k) = Locker k . toAny
 
--- | @fromBox k a@ is analogous to @lookup k a@.
-fromBox :: Key s a -> Box s -> Maybe a
-fromBox (Key k) (Box k' a)
+-- | @unlock k a@ is analogous to @lookup k a@.
+unlock :: Key s a -> Locker s -> Maybe a
+unlock (Key k) (Locker k' a)
   | k == k' = Just $ fromAny a
   | otherwise = Nothing

--- a/vault.cabal
+++ b/vault.cabal
@@ -9,8 +9,8 @@ Description:
   where you can access different bank boxes with different keys;
   hence the name.
   .
-  Also provided is a /box/ type, representing a vault with a single
-  element (think safe deposit box).
+  Also provided is a /locker/ type, representing a vault with a single
+  element.
   
 Category:           Data
 License:            BSD3


### PR DESCRIPTION
These commits:
1. Fix the definition of `adjust` (it used `Map.alter` instead of `Map.adjust`, which slipped through the cracks because of the use of `unsafeCoerce`; ouch!)
2. Switch to a custom `Key` source and an `IntMap`; this should be faster, since `Unique` uses STM and an Integer, whereas this generator uses `atomicModifyIORef` and an Int. The reason `Unique` doesn't do that is because of a [now-fixed GHC bug](http://hackage.haskell.org/trac/ghc/ticket/3838). Ideally, this would be in Data.Unique itself.
3. Add a `Box` type, analogous to a `Vault` with exactly one element. This is the `Universe` type previously discussed; I saw an equivalent in the [develop branch of reactive-banana](https://github.com/HeinrichApfelmus/reactive-banana/blob/develop/reactive-banana/src/Reactive/Banana/Input.hs), and figured an efficient implementation couldn't hurt. The name is by analogy with safe deposit box; it's a little overly-generic for my tastes, but `Universe` doesn't say much.
