### PR TITLE
Fix module dependency for older base package installs

### DIFF
--- a/src/Data/Vault/ST_GHC.hs
+++ b/src/Data/Vault/ST_GHC.hs
@@ -9,8 +9,11 @@ import Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap
 import Data.IORef
 import Control.Monad.ST
-import Control.Monad.ST.Unsafe
-
+#if MIN_VERSION_base(4,4,0)
+import Control.Monad.ST.Unsafe as STUnsafe
+#else
+import Control.Monad.ST as STUnsafe
+#endif
 
 import Data.Unique.Really
 
@@ -38,7 +41,7 @@ empty :: Vault s
 empty = Vault Map.empty
 
 newKey :: ST s (Key s a)
-newKey = Control.Monad.ST.Unsafe.unsafeIOToST $ Key <$> newUnique
+newKey = STUnsafe.unsafeIOToST $ Key <$> newUnique
 
 lookup :: Key s a -> Vault s -> Maybe a
 lookup (Key k) (Vault m) = fromAny <$> Map.lookup k m


### PR DESCRIPTION
Vault doesn't compile against `base < 4.4.0`. 

I ran into this problem while using Haskell Platform 2011.4, which is the current version available in EPEL (I'm running/compiling Haskell applications in a RHEL environment).

You can fix the problem with this patch, or by putting a hard dependency requirement as `base >= 4.4.0` in your cabal file. Since it's just these two lines that require a newer version of base for a minor deprecation/name change, I think it'd be silly to arbitrarily limit people using a still fairly recent version of Haskell-Platform from being able to use your awesome package, so I think it'd be nicer to merge this in.  :smiley:
