### PR TITLE
bump base upper bound for GHC 7.10 compatibility

### DIFF
--- a/vault.cabal
+++ b/vault.cabal
@@ -49,7 +49,7 @@ flag UseGHC
 
 Library
     hs-source-dirs:     src
-    build-depends:      base >= 4.5 && < 4.8,
+    build-depends:      base >= 4.5 && < 4.9,
                         containers >= 0.4 && < 0.6,
                         unordered-containers >= 0.2.3.0 && < 0.3,
                         hashable >= 1.1.2.5 && < 1.3


### PR DESCRIPTION
this makes it build with the current GHC HEAD
