### PR TITLE
Make Key's last type parameter have a nominal role

### DIFF
--- a/src/Data/Vault/ST/ST.hs
+++ b/src/Data/Vault/ST/ST.hs
@@ -1,3 +1,7 @@
+#if __GLASGOW_HASKELL__ >= 708
+{-# LANGUAGE RoleAnnotations #-}
+#endif
+
 module Data.Vault.ST.LAZINESS (
     -- * Vault
     Vault, Key,

--- a/src/Data/Vault/ST/backends/GHC.hs
+++ b/src/Data/Vault/ST/backends/GHC.hs
@@ -18,6 +18,10 @@ fromAny = unsafeCoerce
 newtype Vault s = Vault (Map Unique Any)
 newtype Key s a = Key Unique
 
+#if __GLASGOW_HASKELL__ >= 708
+type role Key phantom nominal
+#endif
+
 newKey = STUnsafe.unsafeIOToST $ Key <$> newUnique
 
 lookup (Key k) (Vault m) = fromAny <$> Map.lookup k m

--- a/src/Data/Vault/ST/backends/GHC.hs
+++ b/src/Data/Vault/ST/backends/GHC.hs
@@ -19,7 +19,8 @@ newtype Vault s = Vault (Map Unique Any)
 newtype Key s a = Key Unique
 
 #if __GLASGOW_HASKELL__ >= 708
-type role Key phantom nominal
+type role Vault nominal
+type role Key nominal nominal
 #endif
 
 newKey = STUnsafe.unsafeIOToST $ Key <$> newUnique

--- a/vault.cabal
+++ b/vault.cabal
@@ -10,7 +10,7 @@ Description:
   hence the name.
   .
   Also provided is a /locker/ type, representing a store for a single element.
-    
+
 Category:           Data
 License:            BSD3
 License-file:       LICENSE
@@ -45,6 +45,8 @@ Library
                         hashable >= 1.1.2.5 && < 1.3
 
     extensions:         CPP
+    if flag(UseGHC) && impl(ghc >= 7.8)
+      extensions:       RoleAnnotations
     ghc-options:        -Wall -fno-warn-missing-signatures
 
     exposed-modules:

--- a/vault.cabal
+++ b/vault.cabal
@@ -45,8 +45,6 @@ Library
                         hashable >= 1.1.2.5 && < 1.3
 
     extensions:         CPP
-    if flag(UseGHC) && impl(ghc >= 7.8)
-      extensions:       RoleAnnotations
     ghc-options:        -Wall -fno-warn-missing-signatures
 
     exposed-modules:


### PR DESCRIPTION
Currently, `Key a` is a simple newtype around `Unique`. What that doesn't convey is an invariant that `a` must correspond to the type of the data in a `Vault`, or bad things can happen:

```haskell
-- Vault.hs
module Main (main) where

import           Data.Coerce (coerce)
import qualified Data.Vault.Lazy as Vault

main :: IO ()
main = do
  ki <- Vault.newKey :: IO (Vault.Key Int)
  ko <- Vault.newKey :: IO (Vault.Key Ordering)
  let v1  = Vault.insert ki 42 Vault.empty
      v2  = Vault.insert ko EQ v1
      ki2 = coerce ko :: Vault.Key Int
  print $ Vault.lookup ki  v2
  print $ Vault.lookup ko  v2
  print $ Vault.lookup ki2 v2
```

```bash
$ runhaskell Vault.hs
Just 42
Just EQ
Just (-5188146770730811392)
```

We can freely `coerce` between `Key`s of different types because GHC infers the type parameter in `Key a` to be phantom. To prevent this, this pull request forces `a` to have a nominal role so that you can't `coerce` your way into undefined behavior like the above example.