### PR TITLE
Allow building with GHC 8.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ matrix:
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.1], sources: [hvr-ghc]}}
     - env: CABALVER=1.24 GHCVER=8.0.1
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1],  sources: [hvr-ghc]}}
+    - env: CABALVER=2.0 GHCVER=8.2.1
+      addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.1],  sources: [hvr-ghc]}}
 
 before_install:
   - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH

--- a/vault.cabal
+++ b/vault.cabal
@@ -39,7 +39,7 @@ flag UseGHC
 
 Library
     hs-source-dirs:     src
-    build-depends:      base >= 4.5 && < 4.10,
+    build-depends:      base >= 4.5 && < 4.11,
                         containers >= 0.4 && < 0.6,
                         unordered-containers >= 0.2.3.0 && < 0.3,
                         hashable >= 1.1.2.5 && < 1.3


### PR DESCRIPTION
`vault` builds just fine with `base-4.10`, so let's adjust the upper version bounds accordingly.