### PR TITLE
Depend on semigroups only on GHC < 8.0

### DIFF
--- a/vault.cabal
+++ b/vault.cabal
@@ -50,9 +50,11 @@ Library
     hs-source-dirs:     src
     build-depends:      base >= 4.5 && < 4.15,
                         containers >= 0.4 && < 0.7,
-                        semigroups >= 0.1 && < 1.0,
                         unordered-containers >= 0.2.3.0 && < 0.3,
                         hashable >= 1.1.2.5 && < 1.4
+
+    if impl(ghc < 8.0)
+        build-depends:  semigroups >= 0.1 && < 1.0
 
     extensions:         CPP
     ghc-options:        -Wall -fno-warn-missing-signatures


### PR DESCRIPTION
They are not needed on newer GHC.