### PR TITLE
Support GHC 9.10.1

### DIFF
--- a/vault.cabal
+++ b/vault.cabal
@@ -1,3 +1,4 @@
+cabal-version:      3.4
 Name:               vault
 Version:            0.3.1.5
 Synopsis:           a persistent store for values of arbitrary types
@@ -12,7 +13,7 @@ Description:
   Also provided is a /locker/ type, representing a store for a single element.
 
 Category:           Data
-License:            BSD3
+License:            BSD-3-Clause
 License-file:       LICENSE
 Author:             Heinrich Apfelmus, Elliott Hird
 Maintainer:         Heinrich Apfelmus <apfelmus at quantentunnel de>
@@ -20,7 +21,6 @@ Homepage:           https://github.com/HeinrichApfelmus/vault
 Copyright:          (c) Heinrich Apfelmus 2011-2013
 
 build-type:         Simple
-cabal-version:      >= 1.10
 Tested-With:         GHC == 7.6.3
                     ,GHC == 7.8.4
                     ,GHC == 7.10.3
@@ -33,8 +33,9 @@ Tested-With:         GHC == 7.6.3
                     ,GHC == 9.0.2
                     ,GHC == 9.2.8
                     ,GHC == 9.4.8
-                    ,GHC == 9.6.4
+                    ,GHC == 9.6.5
                     ,GHC == 9.8.1
+                    ,GHC == 9.10.1
 
 extra-source-files:
     CHANGELOG.md
@@ -53,7 +54,7 @@ flag UseGHC
 
 Library
     hs-source-dirs:     src
-    build-depends:      base >= 4.5 && < 4.20,
+    build-depends:      base >= 4.5 && < 4.21,
                         containers >= 0.4 && < 0.8,
                         unordered-containers >= 0.2.3.0 && < 0.3,
                         hashable >= 1.1.2.5 && < 1.5


### PR DESCRIPTION
This PR bumps the bounds for GHC 9.10.1 and makes use of the cabal file format version 3.4 with proper SPDX license identifier.

closes #42