### PR TITLE
Remove noncanonical definitions

### DIFF
--- a/src/Data/Vault/ST/ST.h
+++ b/src/Data/Vault/ST/ST.h
@@ -44,7 +44,9 @@ instance Semigroup (Vault s) where
 
 instance Monoid (Vault s) where
     mempty = empty
+#if !MIN_VERSION_base(4,11,0)
     mappend = union
+#endif
 
 -- | The empty vault.
 empty :: Vault s


### PR DESCRIPTION
This appeases the -Wnoncanonical-monoid-instances warning. This warning exists because a future GHC release may treat noncanonical definitions as errors.

See also:
  https://gitlab.haskell.org/ghc/ghc/-/wikis/proposal/semigroup-monoid