### PR TITLE
Drop dependency on `hashable` when not compiling with GHC

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -21,7 +21,7 @@ on:
     - cron: 0 18 * * *
 jobs:
   build:
-    name: ${{ matrix.os }}-ghc-${{ matrix.ghc }}
+    name: ${{ matrix.os }}-ghc-${{ matrix.ghc }}-${{ matrix.cabal-flags}}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
@@ -42,6 +42,15 @@ jobs:
           - '9.8'
           - '9.10'
           - '9.12'
+        cabal-flags:
+          - '-f+UseGHC'
+        include:
+          - os: ubuntu-latest
+            cabal: '3.12'
+            ghc: '9.12'
+            cabal-flags: '-f-UseGHC'
+            allow-failure: false
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -55,7 +64,7 @@ jobs:
 
       - name: Configure
         run: |
-          cabal configure \
+          cabal configure ${{ matrix.cabal-flags }} \
             --enable-tests \
             --enable-benchmarks \
             --enable-documentation \
@@ -70,7 +79,7 @@ jobs:
         uses: actions/cache/restore@v4
         id: cache
         env:
-          key: ${{ matrix.os }}-ghc-${{ matrix.ghc }}
+          key: ${{ matrix.os }}-ghc-${{ matrix.ghc }}-${{ matrix.cabal-flags }}
           hash: ${{ hashFiles('**/plan.json') }}
         with:
           key: ${{ env.key }}-${{ env.hash }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Added
 
 * Add module `Data.Unique.Really.Map`
 
+Changed
+
+* Remove dependencies on `hashable` and `unordered-containers`
+  when not compiling with GHC.
+
+Removed
+
+* Remove `instance Hashable Unique` when not compiling with GHC
+* Dropped support for `GHC < 8.4`
+
 **0.3.1.5**
 
 * Compatibility with GHC-9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog for the `vault` package
 
+**0.3.2.0**
+
+Added
+
+* Add module `Data.Unique.Really.Map`
+
 **0.3.1.5**
 
 * Compatibility with GHC-9.0

--- a/src/Data/Unique/Really.hs
+++ b/src/Data/Unique/Really.hs
@@ -3,13 +3,11 @@ module Data.Unique.Really (
     Unique, newUnique, hashUnique,
     ) where
 
-import Data.Hashable
-
 #if UseGHC
-
-import Control.Exception (evaluate)
+import           Control.Exception (evaluate)
+import           Data.Hashable
 import qualified Data.Unique
-import System.Mem.StableName
+import           System.Mem.StableName
 
 -- | An abstract unique value.
 -- Values of type 'Unique' may be compared for equality
@@ -25,6 +23,8 @@ newUnique = do
     Unique <$> makeStableName x
 
 hashUnique (Unique s) = hashStableName s
+
+instance Hashable Unique where hashWithSalt s = hashWithSalt s . hashUnique
 
 #else
 
@@ -61,5 +61,3 @@ newUnique  :: IO Unique
 -- Two Uniques may hash to the same value, although in practice this is unlikely.
 -- The 'Int' returned makes a good hash key.
 hashUnique :: Unique -> Int
-
-instance Hashable Unique where hashWithSalt s = hashWithSalt s . hashUnique

--- a/src/Data/Unique/Really/Map.hs
+++ b/src/Data/Unique/Really/Map.hs
@@ -1,0 +1,49 @@
+-- | A specialized strict 'Map' type suitable for 'Unique' keys.
+--
+-- This type is useful in the rare case that 'Data.HashMap' is not available,
+-- e.g. because you are not compiling with GHC.
+module Data.Unique.Really.Map (
+    UniqueMap,
+    elems, empty, insert, delete
+    ) where
+
+import Data.Unique.Really
+
+#if UseGHC
+
+import qualified Data.HashMap.Strict as Map
+
+-- | A map from 'Unique' to values of type @a@.
+newtype UniqueMap a = UniqueMap (Map.HashMap Unique a)
+
+empty                    = UniqueMap Map.empty
+elems      (UniqueMap m) = Map.elems m
+insert k x (UniqueMap m) = UniqueMap (Map.insert k x m)
+delete k   (UniqueMap m) = UniqueMap (Map.delete k m)
+
+#else
+
+import qualified Data.IntMap.Strict as Map
+
+-- | A map from 'Unique' to values of type @a@.
+newtype UniqueMap a = UniqueMap (Map.IntMap a)
+
+empty                    = UniqueMap Map.empty
+elems      (UniqueMap m) = Map.elems m
+insert k x (UniqueMap m) = UniqueMap (Map.insert (hashUnique k) x m)
+delete k   (UniqueMap m) = UniqueMap (Map.delete (hashUnique k) m)
+
+#endif
+
+-- | The empty map.
+empty :: UniqueMap a
+
+-- | Return all elements of the map.
+elems :: UniqueMap a -> [a]
+
+-- | Insert a new key/value pair in the map.
+--  If the key is already present in the map, the value is replaced with the new one.
+insert :: Unique -> a -> UniqueMap a -> UniqueMap a
+
+-- | Delete a key and its value from the map. 
+delete :: Unique -> UniqueMap a -> UniqueMap a

--- a/vault.cabal
+++ b/vault.cabal
@@ -53,8 +53,6 @@ library
   build-depends:
     , base                  >=4.11    && <4.22
     , containers            >=0.5     && <0.9
-    , hashable              >=1.1.2.5 && <1.6
-    , unordered-containers  >=0.2.3.0 && <0.3
 
   ghc-options:        -Wall -fno-warn-missing-signatures
   hs-source-dirs:     src
@@ -68,3 +66,6 @@ library
 
   if (impl(ghc) && flag(useghc))
     cpp-options: -DUseGHC
+    build-depends:
+      , hashable              >=1.1.2.5 && <1.6
+      , unordered-containers  >=0.2.3.0 && <0.3

--- a/vault.cabal
+++ b/vault.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.4
 name:               vault
-version:            0.3.1.6
+version:            0.3.2.0
 synopsis:           a persistent store for values of arbitrary types
 description:
   A /vault/ is a persistent store for values of arbitrary types.
@@ -60,6 +60,7 @@ library
   hs-source-dirs:     src
   exposed-modules:
     Data.Unique.Really
+    Data.Unique.Really.Map
     Data.Vault.Lazy
     Data.Vault.ST.Lazy
     Data.Vault.ST.Strict


### PR DESCRIPTION
This pull request drops the dependency on `hashable` when not compiling with GHC and adds a module `Data.Unique.Really.Map` to compensate.

The goal is to make this package compile with MicroHs.