### PR TITLE
Make value type of `Key` representational (in GHC backend)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog for the `vault` package
 
+* Make value type of `Key` representational (in GHC backend)
+
 **0.3.1.6**
 
 Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog for the `vault` package
 
+**next version**
+
+Changed
+
 * Make value type of `Key` representational (in GHC backend)
 
 **0.3.1.6**

--- a/src/Data/Vault/ST/backends/GHC.h
+++ b/src/Data/Vault/ST/backends/GHC.h
@@ -20,7 +20,7 @@ newtype Key s a = Key Unique
 
 #if __GLASGOW_HASKELL__ >= 708
 type role Vault nominal
-type role Key nominal nominal
+type role Key nominal representational
 #endif
 
 newKey = unsafeIOToST $ Key <$> newUnique


### PR DESCRIPTION
In case you decide you want to make the value type of `Key` representational, here is a PR that does that. I can make other adjustments you deem necessary too.