### PR TITLE
Fix tests to use the intended backends

### DIFF
--- a/src/Data/Unique/Really.hs
+++ b/src/Data/Unique/Really.hs
@@ -3,62 +3,8 @@ module Data.Unique.Really (
     Unique, newUnique, hashUnique,
     ) where
 
-import           Data.Hashable
-
 #if UseGHC
-import           Control.Exception (evaluate)
-import qualified Data.Unique
-import           System.Mem.StableName
-
--- | An abstract unique value.
--- Values of type 'Unique' may be compared for equality
--- and hashed into Int.
---
--- Note: Unlike the symbols from "Data.Unique", the symbols from this
--- module do not become equal after reloads in the GHC interpreter!
-newtype Unique = Unique (StableName Data.Unique.Unique) deriving (Eq)
-
-newUnique = do
-    x <- Data.Unique.newUnique
-    _ <- evaluate x
-    Unique <$> makeStableName x
-
-hashUnique (Unique s) = hashStableName s
-
+import Data.Unique.Really.GHC
 #else
-
-import Data.IORef
-import System.IO.Unsafe (unsafePerformIO)
-
-{-# NOINLINE refNumber #-}
-refNumber :: IORef Integer
-refNumber = unsafePerformIO $ newIORef 0
-
-newNumber = atomicModifyIORef' refNumber $ \x -> let x' = x+1 in (x', x')
-
--- | An abstract unique value.
--- Values of type 'Unique' may be compared for equality
--- and hashed into Int.
---
--- NOTE: You haven't compiled this module with GHC.
--- The functionality will be identitcal to "Data.Unique".
-newtype Unique = Unique Integer deriving (Eq,Ord)
-
-newUnique = Unique <$> newNumber
-hashUnique (Unique s) = fromIntegral s
-
-
+import Data.Unique.Really.Any
 #endif
-
-instance Hashable Unique where hashWithSalt s = hashWithSalt s . hashUnique
-
--- | Creates a new object of type 'Unique'.
--- The value returned will not compare equal to any other
--- value of type 'Unique' returned by previous calls to 'newUnique'.
--- There is no limit on the number of times you may call this function.
-newUnique  :: IO Unique
-
--- | Hashes a 'Unique' into an 'Int'.
--- Two Uniques may hash to the same value, although in practice this is unlikely.
--- The 'Int' returned makes a good hash key.
-hashUnique :: Unique -> Int

--- a/src/Data/Unique/Really/Any.hs
+++ b/src/Data/Unique/Really/Any.hs
@@ -1,0 +1,3 @@
+#define MODULE_NAME Data.Unique.Really.Any
+#undef  BACKEND_GHC
+#include "Core.h"

--- a/src/Data/Unique/Really/Core.h
+++ b/src/Data/Unique/Really/Core.h
@@ -1,0 +1,64 @@
+-- | An abstract interface to a unique symbol generator.
+module MODULE_NAME (
+    Unique, newUnique, hashUnique,
+    ) where
+
+import           Data.Hashable
+
+#if BACKEND_GHC
+import           Control.Exception (evaluate)
+import qualified Data.Unique
+import           System.Mem.StableName
+
+-- | An abstract unique value.
+-- Values of type 'Unique' may be compared for equality
+-- and hashed into Int.
+--
+-- Note: Unlike the symbols from "Data.Unique", the symbols from this
+-- module do not become equal after reloads in the GHC interpreter!
+newtype Unique = Unique (StableName Data.Unique.Unique) deriving (Eq)
+
+newUnique = do
+    x <- Data.Unique.newUnique
+    _ <- evaluate x
+    Unique <$> makeStableName x
+
+hashUnique (Unique s) = hashStableName s
+
+#else
+
+import Data.IORef
+import System.IO.Unsafe (unsafePerformIO)
+
+{-# NOINLINE refNumber #-}
+refNumber :: IORef Integer
+refNumber = unsafePerformIO $ newIORef 0
+
+newNumber = atomicModifyIORef' refNumber $ \x -> let x' = x+1 in (x', x')
+
+-- | An abstract unique value.
+-- Values of type 'Unique' may be compared for equality
+-- and hashed into Int.
+--
+-- NOTE: You haven't compiled this module with GHC.
+-- The functionality will be identitcal to "Data.Unique".
+newtype Unique = Unique Integer deriving (Eq,Ord)
+
+newUnique = Unique <$> newNumber
+hashUnique (Unique s) = fromIntegral s
+
+
+#endif
+
+instance Hashable Unique where hashWithSalt s = hashWithSalt s . hashUnique
+
+-- | Creates a new object of type 'Unique'.
+-- The value returned will not compare equal to any other
+-- value of type 'Unique' returned by previous calls to 'newUnique'.
+-- There is no limit on the number of times you may call this function.
+newUnique  :: IO Unique
+
+-- | Hashes a 'Unique' into an 'Int'.
+-- Two Uniques may hash to the same value, although in practice this is unlikely.
+-- The 'Int' returned makes a good hash key.
+hashUnique :: Unique -> Int

--- a/src/Data/Unique/Really/GHC.hs
+++ b/src/Data/Unique/Really/GHC.hs
@@ -1,0 +1,3 @@
+#define MODULE_NAME Data.Unique.Really.GHC
+#define BACKEND_GHC 1
+#include "Core.h"

--- a/src/Data/Vault/Lazy.hs
+++ b/src/Data/Vault/Lazy.hs
@@ -1,5 +1,6 @@
 #define LAZINESS Lazy
 #define MODULE_NAME Data.Vault.Lazy
+-- BACKEND_GHC is fixed by the import of Data.Vault.ST.*
 
 -- | A persistent store for values of arbitrary types.
 --

--- a/src/Data/Vault/ST/Lazy.hs
+++ b/src/Data/Vault/ST/Lazy.hs
@@ -1,4 +1,8 @@
-#define LAZINESS Lazy
+#define LAZINESS    Lazy
+#define MODULE_NAME Data.Vault.ST.Lazy
+#if UseGHC
+#define BACKEND_GHC 1
+#endif
 
 -- | A persistent store for values of arbitrary types.
 -- Variant for the 'ST' monad.

--- a/src/Data/Vault/ST/ST.h
+++ b/src/Data/Vault/ST/ST.h
@@ -2,7 +2,7 @@
 {-# LANGUAGE RoleAnnotations #-}
 #endif
 
-module Data.Vault.ST.LAZINESS (
+module MODULE_NAME (
     -- * Vault
     Vault, Key,
     empty, newKey, lookup, insert, adjust, delete, union,
@@ -16,8 +16,6 @@ import Prelude hiding (lookup)
 import Control.Monad.ST
 import Control.Monad.ST.Unsafe (unsafeIOToST)
 
-import Data.Unique.Really
-
 {-
     The GHC-specific implementation uses  unsafeCoerce
     for reasons of efficiency.
@@ -26,7 +24,7 @@ import Data.Unique.Really
     for the second implementation that doesn't need to
     bypass the type checker.
 -}
-#if UseGHC
+#if BACKEND_GHC
 #include "backends/GHC.h"
 #else
 #include "backends/IORef.hs"

--- a/src/Data/Vault/ST/Strict.hs
+++ b/src/Data/Vault/ST/Strict.hs
@@ -1,5 +1,9 @@
-#define LAZINESS Strict
+#define LAZINESS    Strict
+#define MODULE_NAME Data.Vault.ST.Strict
 #define IsStrict 1
+#if UseGHC
+#define BACKEND_GHC 1
+#endif
 
 -- | A persistent store for values of arbitrary types.
 -- Variant for the 'ST' monad.

--- a/src/Data/Vault/ST/backends/GHC.h
+++ b/src/Data/Vault/ST/backends/GHC.h
@@ -4,6 +4,7 @@
 -- implementation is more efficient than the alternative implementation
 -- in terms of IORef.
 
+import Data.Unique.Really.GHC
 import GHC.Exts (Any)
 import Unsafe.Coerce (unsafeCoerce)
 

--- a/src/Data/Vault/ST/backends/IORef.hs
+++ b/src/Data/Vault/ST/backends/IORef.hs
@@ -1,4 +1,5 @@
 import Data.IORef
+import Data.Unique.Really.Any
 import System.IO.Unsafe (unsafePerformIO)
 
 import qualified Data.Map.LAZINESS as Map

--- a/src/Data/Vault/Strict.hs
+++ b/src/Data/Vault/Strict.hs
@@ -1,5 +1,7 @@
 #define LAZINESS Strict
 #define MODULE_NAME Data.Vault.Strict
+-- BACKEND_GHC is fixed by the import of Data.Vault.ST.*
+
 
 -- | A persistent store for values of arbitrary types.
 --

--- a/src/Internal/Data/Vault/ST/IORef.hs
+++ b/src/Internal/Data/Vault/ST/IORef.hs
@@ -1,8 +1,8 @@
 #define LAZINESS Lazy
-#undef  UseGHC
-#define MODULE_NAME Internal.Data.Vault.IORef
+#define MODULE_NAME Internal.Data.Vault.ST.IORef
+#undef  BACKEND_GHC
 
 -- | FOR TESTING ONLY. DO NOT USE!
 --
 -- 'Vault' implementation using 'IORef' for testing purposes.
-#include "../../../Data/Vault/IO.h"
+#include "../../../../Data/Vault/ST/ST.h"

--- a/test/Data/Vault/LazySpec.hs
+++ b/test/Data/Vault/LazySpec.hs
@@ -1,6 +1,0 @@
-module Data.Vault.LazySpec (spec) where
-
-#define MODULE_UNDER_TEST Data.Vault.Lazy
-#define TEST_NAME "Data.Vault.Lazy"
-
-#include "Spec.h"

--- a/test/Data/Vault/ST/LazySpec.hs
+++ b/test/Data/Vault/ST/LazySpec.hs
@@ -1,0 +1,6 @@
+module Data.Vault.ST.LazySpec (spec) where
+
+#define MODULE_UNDER_TEST Data.Vault.ST.Lazy
+#define TEST_NAME "Data.Vault.ST.Lazy"
+
+#include "../Spec.h"

--- a/test/Data/Vault/Spec.h
+++ b/test/Data/Vault/Spec.h
@@ -1,6 +1,11 @@
 import Prelude hiding (lookup)
+
+import Control.Monad.ST (RealWorld, stToIO)
 import Test.Hspec
 import MODULE_UNDER_TEST
+
+newKey' :: IO (Key RealWorld a)
+newKey' = stToIO newKey
 
 spec :: Spec
 spec = describe TEST_NAME $ do
@@ -8,16 +13,16 @@ spec = describe TEST_NAME $ do
   describe "Locker" $ do
 
     it "unlock retrieves locked item" $ do
-      key <- newKey :: IO (Key Int)
+      key <- newKey' :: IO (Key RealWorld Int)
       unlock key (lock key 42) `shouldBe` Just 42
 
     it "unlock with different key retrieves Nothing" $ do
-      key  <- newKey :: IO (Key Int)
-      key' <- newKey :: IO (Key Int)
+      key  <- newKey' :: IO (Key RealWorld Int)
+      key' <- newKey' :: IO (Key RealWorld Int)
       unlock key' (lock key 42) `shouldBe` Nothing
 
   describe "Vault" $ do
 
     it "lookup empty returns Nothing" $ do
-      key <- newKey :: IO (Key Int)
+      key <- newKey' :: IO (Key RealWorld Int)
       lookup key empty `shouldBe` Nothing

--- a/test/Internal/Data/Vault/IORefSpec.hs
+++ b/test/Internal/Data/Vault/IORefSpec.hs
@@ -1,6 +1,0 @@
-module Internal.Data.Vault.IORefSpec (spec) where
-
-#define MODULE_UNDER_TEST Internal.Data.Vault.IORef
-#define TEST_NAME "Internal.Data.Vault.IORef"
-
-#include "../../../Data/Vault/Spec.h"

--- a/test/Internal/Data/Vault/ST/IORefSpec.hs
+++ b/test/Internal/Data/Vault/ST/IORefSpec.hs
@@ -1,0 +1,6 @@
+module Internal.Data.Vault.ST.IORefSpec (spec) where
+
+#define MODULE_UNDER_TEST Internal.Data.Vault.ST.IORef
+#define TEST_NAME "Internal.Data.Vault.ST.IORef"
+
+#include "../../../../Data/Vault/Spec.h"

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,10 +1,10 @@
 module Main (main) where
  
 import Test.Hspec
-import qualified Data.Vault.LazySpec
-import qualified Internal.Data.Vault.IORefSpec
+import qualified Data.Vault.ST.LazySpec
+import qualified Internal.Data.Vault.ST.IORefSpec
  
 main :: IO ()
 main = hspec $ do
-  Data.Vault.LazySpec.spec
-  Internal.Data.Vault.IORefSpec.spec
+  Data.Vault.ST.LazySpec.spec
+  Internal.Data.Vault.ST.IORefSpec.spec

--- a/vault.cabal
+++ b/vault.cabal
@@ -38,6 +38,7 @@ tested-with:
    || ==9.12.4
 
 extra-source-files:
+  src/Data/Unique/Really/Core.h
   src/Data/Vault/IO.h
   src/Data/Vault/ST/backends/GHC.h
   src/Data/Vault/ST/backends/IORef.hs
@@ -73,6 +74,9 @@ library
     Data.Vault.ST.Strict
     Data.Vault.Strict
     Internal.Data.Vault.IORef
+  other-modules:
+    Data.Unique.Really.Any
+    Data.Unique.Really.GHC
 
   if (impl(ghc) && flag(useghc))
     cpp-options: -DUseGHC

--- a/vault.cabal
+++ b/vault.cabal
@@ -73,7 +73,7 @@ library
     Data.Vault.ST.Lazy
     Data.Vault.ST.Strict
     Data.Vault.Strict
-    Internal.Data.Vault.IORef
+    Internal.Data.Vault.ST.IORef
   other-modules:
     Data.Unique.Really.Any
     Data.Unique.Really.GHC
@@ -97,5 +97,5 @@ test-suite test
 
   main-is:            Spec.hs
   other-modules:
-    Data.Vault.LazySpec
-    Internal.Data.Vault.IORefSpec
+    Data.Vault.ST.LazySpec
+    Internal.Data.Vault.ST.IORefSpec


### PR DESCRIPTION
This pull request fixes a bug where the module `Internal.Data.Vault.IORef` was not actually compiled with the IORef backend when using GHC.